### PR TITLE
Replace done(...) with next().returns(...)

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,11 @@ module.exports = function fromGenerator (t, generator) {
       return t.deepEqual(fn(mock).value, effect.apply(null, args))
     }
   }
+  var _returns = function (fn, mock) {
+    return function (value) {
+      return t.deepEqual(fn(mock), {done: true, value: value})
+    }
+  }
   function wrap (fn) {
     return function (mock) {
       return {
@@ -31,7 +36,8 @@ module.exports = function fromGenerator (t, generator) {
         cancel: _nextIs(fn, mock, effects.cancel),
         select: _nextIs(fn, mock, effects.select),
         actionChannel: _nextIs(fn, mock, effects.actionChannel),
-        cancelled: _nextIs(fn, mock, effects.cancelled)
+        cancelled: _nextIs(fn, mock, effects.cancelled),
+        returns: _returns(fn, mock)
       }
     }
   }
@@ -51,7 +57,7 @@ module.exports = function fromGenerator (t, generator) {
       return t.deepEqual(_next().value, saga.takeLatest.apply(null, args).next().value)
     },
     done: function (value) {
-      return t.deepEqual(_next(), {done: true, value: value})
+      return this.next().returns(value)
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ test('saga', (t) => {
   expect.next().put({type: 'FETCHING'})
   expect.next().call(loadData)
   expect.next(mockData).put({type: 'FETCHED', payload: mockData})
+  expect.next().returns()
 })
 ```
 

--- a/test.js
+++ b/test.js
@@ -82,16 +82,28 @@ function * returnSaga () {
   return 'return'
 }
 
-test('done', (t) => {
+function * returnValue () {
+  const value = yield take('ACTION')
+  return value
+}
+
+test('returns nothing', (t) => {
   const expect = fromGenerator(t, doneSaga())
 
   expect.next().take('ACTION')
-  expect.done()
+  expect.next().returns()
 })
 
-test('done with return', (t) => {
+test('returns something', (t) => {
   const expect = fromGenerator(t, returnSaga())
 
   expect.next().take('ACTION')
-  expect.done('return')
+  expect.next().returns('return')
+})
+
+test('returns what was yielded', (t) => {
+  const expect = fromGenerator(t, returnValue())
+
+  expect.next().take('ACTION')
+  expect.next('yielded').returns('yielded')
 })


### PR DESCRIPTION
Previously there was no way to specify a yielded value for the last
yield, `done()` would always call `next()` with no value.

I left `done()` but I would be happy to remove it or deprecate it depending on your release policy. Given that this is only for test code, maybe it'd be fine to just remove it?